### PR TITLE
Write FO surface to specified output directory, rather than 'output'

### DIFF
--- a/rhic/src/HydroPlugin.cpp
+++ b/rhic/src/HydroPlugin.cpp
@@ -143,8 +143,9 @@ void run(void * latticeParams, void * initCondParams, void * hydroParams, const 
 
   //open the freezeout surface file
   ofstream freezeoutSurfaceFile;
-  if (FOFORMAT == 0) freezeoutSurfaceFile.open("output/surface.dat");
-  else freezeoutSurfaceFile.open("output/surface.dat", ios::binary);
+  std::string surf_fname = std::string(outputDir) + std::string("/surface.dat");
+  if (FOFORMAT == 0) freezeoutSurfaceFile.open(surf_fname);
+  else freezeoutSurfaceFile.open(surf_fname, ios::binary);
   /************************************************************************************	\
   * Fluid dynamic initialization
   /************************************************************************************/


### PR DESCRIPTION
CPU-VH would try to write to "output/surface.dat" regardless of what output directory was provided with the -o flag. Now, it should write to the provided directory name.